### PR TITLE
add rtt_ros from automated build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - BEFORE_SCRIPT="export CXX='ccache g++' CC='ccache gcc' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
-    - ADDITIONAL_DEBS="ccache curl"
+    - BEFORE_SCRIPT="export CXX='ccache g++-5' CC='ccache gcc-5' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
+    - ADDITIONAL_DEBS="ccache curl g++-5 gcc-5"
     - CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --"
     - ROS_PARALLEL_JOBS="-j6"
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - BEFORE_SCRIPT="export CXX='ccache g++-5' CC='ccache gcc-5' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
-    - ADDITIONAL_DEBS="ccache curl g++-5 gcc-5"
+    - BEFORE_SCRIPT="add-apt-repository ppa:ubuntu-toolchain-r/test && apt-get update && apt-get install g++-5 gcc-5 && export CXX='ccache g++-5' CC='ccache gcc-5' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
+    - ADDITIONAL_DEBS="ccache curl"
     - CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --"
     - ROS_PARALLEL_JOBS="-j6"
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - BEFORE_SCRIPT="add-apt-repository ppa:ubuntu-toolchain-r/test && apt-get update && apt-get install g++-5 gcc-5 && export CXX='ccache g++-5' CC='ccache gcc-5' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
+    - BEFORE_SCRIPT="add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get -q update && apt-get install -y -qq g++-5 gcc-5 && export CXX='ccache g++-5' CC='ccache gcc-5' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
     - ADDITIONAL_DEBS="ccache curl software-properties-common"
     - CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --"
     - ROS_PARALLEL_JOBS="-j6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - BEFORE_SCRIPT="source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
+    - BEFORE_SCRIPT="source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh) && source /usr/share/gazebo/setup.sh"
     - ADDITIONAL_DEBS="curl"
     
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - BEFORE_SCRIPT="add-apt-repository ppa:ubuntu-toolchain-r/test && apt-get update && apt-get install g++-5 gcc-5 && export CXX='ccache g++-5' CC='ccache gcc-5' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
-    - ADDITIONAL_DEBS="ccache curl"
+    - ADDITIONAL_DEBS="ccache curl software-properties-common"
     - CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --"
     - ROS_PARALLEL_JOBS="-j6"
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - BEFORE_SCRIPT="source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh) && source /usr/share/gazebo/setup.sh"
+    - BEFORE_SCRIPT="source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
     - ADDITIONAL_DEBS="curl"
     
   matrix:
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="jade"
-    - ROS_DISTRO="kinetic" CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --"
+    - ROS_DISTRO="kinetic" CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --" ADDITIONAL_DEBS="curl libgazebo7-dev"
 
 install:
   - git clone https://github.com/ipa-mdl/industrial_ci -b fix/install-space .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ env:
     - ROS_DISTRO="kinetic" CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --" ADDITIONAL_DEBS="curl libgazebo7-dev"
 
 install:
-  - git clone https://github.com/ipa-mdl/industrial_ci -b fix/install-space .ci_config
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:
   - source .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - BEFORE_SCRIPT="source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
+    - BEFORE_SCRIPT="source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_release.sh)"
     - ADDITIONAL_DEBS="curl"
     
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ env:
     - ROS_DISTRO="kinetic"
 
 install:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+  - git clone https://github.com/ipa-mdl/industrial_ci -b fix/install-space .ci_config
 script:
   - source .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,13 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - NOT_TEST_BUILD=true
-    - NOT_TEST_INSTALL=true
+    - BEFORE_SCRIPT="export CXX='ccache g++' CC='ccache gcc' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
+    - ADDITIONAL_DEBS="ccache curl"
     
   matrix:
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="jade"
     - ROS_DISTRO="kinetic"
-
-matrix:
-  allow_failures:
-    - env: ROS_DISTRO="kinetic"
 
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - BEFORE_SCRIPT="export CXX='ccache g++' CC='ccache gcc' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
     - ADDITIONAL_DEBS="ccache curl"
+    - CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std-c++11 --"
+    - ROS_PARALLEL_JOBS="-j6"
     
   matrix:
     - ROS_DISTRO="indigo"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,13 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - BEFORE_SCRIPT="add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get -q update && apt-get install -y -qq g++-5 gcc-5 && export CXX='ccache g++-5' CC='ccache gcc-5' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
-    - ADDITIONAL_DEBS="ccache curl software-properties-common"
-    - CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --"
-    - ROS_PARALLEL_JOBS="-j6"
+    - BEFORE_SCRIPT="source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
+    - ADDITIONAL_DEBS="curl"
     
   matrix:
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="jade"
-    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="kinetic" CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --"
 
 install:
   - git clone https://github.com/ipa-mdl/industrial_ci -b fix/install-space .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - BEFORE_SCRIPT="export CXX='ccache g++' CC='ccache gcc' && source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
     - ADDITIONAL_DEBS="ccache curl"
-    - CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std-c++11 --"
+    - CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --"
     - ROS_PARALLEL_JOBS="-j6"
     
   matrix:


### PR DESCRIPTION
as rtt and rtt_ros are not released to kinetic yet, this PR adds those packages precompiled in an automated build : 

https://github.com/ahoarau/orocos_toolchain-build
https://github.com/ahoarau/rtt_ros_integration-build
